### PR TITLE
Add support for finishOnKey in Gather blocks

### DIFF
--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -96,7 +96,7 @@ module TwilioTestToolkit
       path = gather_action
 
       # Update the root call
-      root_call.request_for_twiml!(path, :digits => digits, :method => gather_method)
+      root_call.request_for_twiml!(path, :digits => digits, :method => gather_method, :finish_on_key => gather_finish_on_key)
     end
 
     # Some basic accessors

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -84,6 +84,11 @@ module TwilioTestToolkit
       return @xml["method"]
     end
 
+    def gather_finish_on_key
+      raise "Not a gather" unless gather?
+      return @xml["finishOnKey"]
+    end
+
     def press(digits)
       raise "Not a gather" unless gather?
 

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -121,6 +121,16 @@ module TwilioTestToolkit
         @xml.at_xpath("Gather")      
       end
 
+      def formatted_digits(digits, options = {})
+        if digits.nil?
+          ''
+        elsif options[:finish_on_key]
+          digits.split(options[:finish_on_key])[0]
+        else
+          digits
+        end
+      end
+
     protected
       # New object creation
       def self.from_xml(parent, xml)

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -174,7 +174,7 @@ module TwilioTestToolkit
           :format => :xml, 
           :CallSid => @root_call.sid, 
           :From => @root_call.from_number, 
-          :Digits => options[:digits] || "",
+          :Digits => formatted_digits(options[:digits], :finish_on_key => options[:finish_on_key]),
           :To => @root_call.to_number,
           :AnsweredBy => (options[:is_machine] ? "machine" : "human")
         )

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -86,7 +86,7 @@ module TwilioTestToolkit
 
     def gather_finish_on_key
       raise "Not a gather" unless gather?
-      return @xml["finishOnKey"]
+      return @xml["finishOnKey"] || '#' # '#' is the default finish key if not specified
     end
 
     def press(digits)

--- a/spec/dummy/app/views/twilio/test_action.xml.erb
+++ b/spec/dummy/app/views/twilio/test_action.xml.erb
@@ -1,2 +1,2 @@
-<Say voice="woman">You entered <%= @digits %></Say>
+<Say voice="woman">You entered <%= @digits %>.</Say>
 <Redirect><%= twilio_index_path %></Redirect>

--- a/spec/dummy/app/views/twilio/test_gather_finish_on_asterisk.xml.erb
+++ b/spec/dummy/app/views/twilio/test_gather_finish_on_asterisk.xml.erb
@@ -1,0 +1,3 @@
+<Gather finishOnKey="*" action="<%= test_action_twilio_index_path %>" method="post">
+	<Say>Please enter some digits followed by hash.</Say>
+</Gather>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Dummy::Application.routes.draw do
     post "test_start", :on => :collection
     post "test_action", :on => :collection
         
+    post "test_gather_finish_on_asterisk", :on => :collection
     post "test_hangup", :on => :collection
     post "test_dial", :on => :collection
     post "test_redirect", :on => :collection

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -248,6 +248,29 @@ describe TwilioTestToolkit::CallScope do
       end
     end
     
+    describe "with finishOnKey specified" do
+      before(:each) do
+        @call = ttt_call(test_gather_finish_on_asterisk_twilio_index_path, @our_number, @their_number)
+      end
+
+      it "should strip the finish key from the digits" do
+        @call.within_gather do |gather|
+          gather.press "98765*"
+        end
+
+        @call.should have_say "You entered 98765."
+      end
+
+      it "should still accept the digits without a finish key (due to timeout)" do
+        @call.within_gather do |gather|
+          gather.press "98765"
+        end
+
+        @call.should have_say "You entered 98765."
+      end
+
+    end
+
     describe "failure" do
       before(:each) do
         @call = ttt_call(test_say_twilio_index_path, @our_number, @their_number)

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -246,6 +246,13 @@ describe TwilioTestToolkit::CallScope do
         # We should still be on the same page
         @call.current_path.should == test_start_twilio_index_path
       end
+
+      it "should respond to the default finish key of hash" do
+        @call.within_gather do |gather|
+          gather.press "98765#"
+        end
+        @call.should have_say "You entered 98765."
+      end
     end
     
     describe "with finishOnKey specified" do

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -235,7 +235,7 @@ describe TwilioTestToolkit::CallScope do
         @call.current_path.should == test_action_twilio_index_path
         
         # This view says the digits we pressed - make sure
-        @call.should have_say "You entered 98765"
+        @call.should have_say "You entered 98765."
       end
       
       it "should gather without a press" do


### PR DESCRIPTION
If a finish key is specified it will take everything up to that key and ignore the rest, as if Twilio had moved on and stopped listening to presses.

If the key isn't pressed at all, an exception is raised.
