### PR TITLE
Add CallStatus to request parameters

### DIFF
--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -8,18 +8,18 @@ module TwilioTestToolkit
       return normalize_redirect_path(el.text) == normalize_redirect_path(url)
     end
 
-    def follow_redirect
+    def follow_redirect(options = {})
       el = get_redirect_node
       raise "No redirect" if el.nil?
 
-      return CallScope.from_request(self, el.text, :method =>el[:method])
+      return CallScope.from_request(self, el.text, { :method =>el[:method]}.merge(options))
     end
 
-    def follow_redirect!
+    def follow_redirect!(options = {})
       el = get_redirect_node
       raise "No redirect" if el.nil?
 
-      request_for_twiml!(normalize_redirect_path(el.text), :method => el[:method])
+      request_for_twiml!(normalize_redirect_path(el.text), { :method => el[:method] }.merge(options))
     end
 
     # Stuff for Says
@@ -156,7 +156,7 @@ module TwilioTestToolkit
       def self.from_request(parent, path, options = {})
         new_scope = CallScope.new
         new_scope.send(:root_call=, parent.root_call)
-        new_scope.send(:request_for_twiml!, path, :digits => options[:digits] || "", :method => options[:method] || :post)
+        new_scope.send(:request_for_twiml!, path, options)
         return new_scope
       end
 
@@ -180,9 +180,10 @@ module TwilioTestToolkit
           :format => :xml,
           :CallSid => @root_call.sid,
           :From => @root_call.from_number,
-          :Digits => formatted_digits(options[:digits], :finish_on_key => options[:finish_on_key]),
+          :Digits => formatted_digits(options[:digits].to_s, :finish_on_key => options[:finish_on_key]),
           :To => @root_call.to_number,
-          :AnsweredBy => (options[:is_machine] ? "machine" : "human")
+          :AnsweredBy => (options[:is_machine] ? "machine" : "human"),
+          :CallStatus => options.fetch(:call_status, "in-progress")
         )
 
         # All Twilio responses must be a success.

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -80,8 +80,43 @@ describe TwilioTestToolkit::CallScope do
         # Make sure it followed
         @call.current_path.should == test_start_twilio_index_path
       end
+
+      it "should submit default params on follow_redirect" do
+        default_request_params = {
+          :format => :xml,
+          :From => "2065551212",
+          :Digits => "",
+          :To => "2065553434",
+          :AnsweredBy => "human",
+          :CallStatus => "in-progress"
+        }
+        Capybara.current_session.driver
+          .should_receive(:post)
+          .with("/twilio/test_start", hash_including(default_request_params))
+          .and_call_original
+
+        @call.follow_redirect
+      end
+
+      it "should consider options for follow_redirect!" do
+        Capybara.current_session.driver
+          .should_receive(:post)
+          .with("/twilio/test_start", hash_including(:CallStatus => "completed"))
+          .and_call_original
+
+        @call.follow_redirect!(call_status: "completed")
+      end
+
+      it "should consider options for follow_redirect" do
+        Capybara.current_session.driver
+          .should_receive(:post)
+          .with("/twilio/test_start", hash_including(:CallStatus => "completed"))
+          .and_call_original
+
+        @call.follow_redirect(call_status: "completed")
+      end
     end
-    
+
     describe "failure" do
       before(:each) do
         # Initiate a call that's not on a redirect - various calls will fail


### PR DESCRIPTION
Twilio always passes CallStatus parameter when following redirects. I added it too. Didn't find a good place to test it, I think it would involve interrogating Capybara a lot. It would also be nice to customize this option in follow_redirect e.g.
if there is a `Play` followed by a `Redirect` twilio will still follow the redirect if the person hangs up, but the CallStatus will be "completed" instead of "in-progress". Let me know if you want me to add this.
