### PR TITLE
Dynamic methods in call scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/dummy/.sass-cache
 *.sqlite3
 
 *.log
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -167,17 +167,17 @@ You can check the existence of any element by using the `#has_foo?` pattern
 where `foo` is your element. Pass in an optional string to check that the string
 is found in the element's inner text:
 
-  @call.has_sms?("Please make sure you foo the bar.")
+	@call.has_sms?("Please make sure you foo the bar.")
 
 You can also check that a given attribute exists on any element using
 a `#has_bar_on_foo?` pattern:
 
-  @call.has_from_on_sms?("+18885551234")
+	@call.has_from_on_sms?("+18885551234")
 
 Or for camel case attributes you can do either of the following:
 
-  @call.has_finishOnKey_on_record?("#")
-  @call.has_finish_on_key_on_record?("#")
+	@call.has_finishOnKey_on_record?("#")
+	@call.has_finish_on_key_on_record?("#")
 
 These methods are available on any CallScope.
 	

--- a/README.md
+++ b/README.md
@@ -162,7 +162,23 @@ A common thing you'll want to do is inspect the various Say elements, and check 
 	@call.has_dial?("911")	# Returns true if there's a <Dial> in the current scope 
 							# for the number. Partial matches are OK.
 	@call.has_hangup?		# Returns true if there's a <Hangup> in the current scope.
-	
+
+You can check the existence of any element by using the `#has_foo?` pattern
+where `foo` is your element. Pass in an optional string to check that the string
+is found in the element's inner text:
+
+  @call.has_sms?("Please make sure you foo the bar.")
+
+You can also check that a given attribute exists on any element using
+a `#has_bar_on_foo?` pattern:
+
+  @call.has_from_on_sms?("+18885551234")
+
+Or for camel case attributes you can do either of the following:
+
+  @call.has_finishOnKey_on_record?("#")
+  @call.has_finish_on_key_on_record?("#")
+
 These methods are available on any CallScope.
 	
 Gathers


### PR DESCRIPTION
Take advantage of Ruby's dynamic nature to make future additions for TwiML nouns and verbs tests a little easier. Calling `#has_foo?` or `#has_foo?("bar")` for any `foo` will now just work. When passed `"bar"`, the default behaviour is to do a substring match on the element's `.inner_text` property. If an exact match is needed as the case was/is with `#has_play?`, a class call to `#has_element` will be necessary. e.g.:

```
has_element "Foo", :exact_inner_match => true
```

This will create `#has_foo?(inner)` using an exact match.

There is also a `has_bar_on_foo?(bat)` pattern where bar can either be the equivalent of TwiML-style lowercase camelCase attributes, or a Ruby snake_case. The following two calls are same:

```
has_finishOnKey_on_record?("#")
has_finish_on_key_on_record("#")
```

... which will check for:

```
<Record finishOnKey="#"></Record>
```

Care was taken to preserve the previous behaviour of the has_nnnn? methods.
