### PR TITLE
Make it easier/possible to test REST API-initiated calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    twilio-test-toolkit (4.0.0)
+    twilio-test-toolkit (3.4.1)
       capybara
       uuidtools
 
@@ -37,7 +37,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     builder (3.0.4)
-    capybara (2.2.1)
+    capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -56,10 +56,10 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
-    mini_portile (0.5.2)
+    mini_portile (0.6.2)
     multi_json (1.8.4)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.6.6.4)
+      mini_portile (~> 0.6.0)
     polyglot (0.3.3)
     rack (1.4.5)
     rack-cache (1.2)
@@ -116,7 +116,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.38)
-    uuidtools (2.1.4)
+    uuidtools (2.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -131,3 +131,6 @@ DEPENDENCIES
   sqlite3
   sqlite3-ruby
   twilio-test-toolkit!
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Options are:
 * **method** . Specify the http method of the initial request. By default this will be :post.
 * **call_sid**. Specify an optional fixed value to be passed as params[:CallSid]. This is useful if you are expecting a specific SID. For instance, a common pattern is to initiate a call, store the SID in your database, and look up the call when you get the callback. If you don't pass a SID, TTT will generate one for you that's just a UUID.
 * **is_machine**. Controls params[:AnsweredBy]. See Twilio's documentation for more information on how Twilio uses this.
+* **direction**. Controls params[:Direction]. Should be: inbound, outbound-api, or outbound-dial
+* **called**. Controls params[:Called]. This is present in a REST API-initiated call.
 
 *ttt_call* returns a *TwilioTestToolkit::CallInProgress* object, which is a descendent of *TwilioTestToolkit::CallScope*. You'll want to save this object as it's how you interact with TTT.
 
@@ -128,6 +130,8 @@ You can use the CallInProgress object returned from *ttt_call* to inspect some b
 	@call.from_number	# Returns the from number
 	@call.to_number		# Returns the to number
 	@call.is_machine	# Returns the answering machine state (passed to ttt_call)
+	@call.direction   # Returns the direction of the call (inbound, outbound-api, outbound-dial)
+	@call.called      # Returns the Called number in the case of an outbound-api call
 
 Call scopes
 --------------

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Options are:
 * **is_machine**. Controls params[:AnsweredBy]. See Twilio's documentation for more information on how Twilio uses this.
 * **direction**. Controls params[:Direction]. Should be: inbound, outbound-api, or outbound-dial
 * **called**. Controls params[:Called]. This is present in a REST API-initiated call.
+* **call_status**. Controls params[:CallStatus]. Defaults to `in-progress`. See [help article](https://www.twilio.com/help/faq/voice/what-do-the-call-statuses-mean) on call statuses.
 
 *ttt_call* returns a *TwilioTestToolkit::CallInProgress* object, which is a descendent of *TwilioTestToolkit::CallScope*. You'll want to save this object as it's how you interact with TTT.
 

--- a/lib/twilio-test-toolkit/call_in_progress.rb
+++ b/lib/twilio-test-toolkit/call_in_progress.rb
@@ -1,5 +1,5 @@
 require "twilio-test-toolkit/call_scope"
-  
+
 module TwilioTestToolkit
   # Models a call
   class CallInProgress < CallScope
@@ -10,10 +10,12 @@ module TwilioTestToolkit
     def initialize(initial_path, from_number, to_number, options = {})
       # Save our variables for later
       @initial_path = initial_path
-      @from_number = from_number
-      @to_number = to_number
-      @is_machine = options[:is_machine]
-      @method = options[:method] || :post
+      @from_number  = from_number
+      @to_number    = to_number
+      @is_machine   = options[:is_machine]
+      @called       = options[:called]
+      @direction    = options[:direction]
+      @method       = options[:method] || :post
 
       # Generate an initial call SID if we don't have one
       if (options[:call_sid].nil?)
@@ -26,25 +28,30 @@ module TwilioTestToolkit
       self.root_call = self
 
       # Create the request
-      request_for_twiml!(@initial_path, :method => @method, :is_machine => @is_machine)
+      request_for_twiml!(@initial_path,
+                         :method     => @method,
+                         :is_machine => @is_machine,
+                         :called     => @called,
+                         :direction  => @direction
+                        )
     end
 
     def sid
       @sid
-    end      
-  
+    end
+
     def initial_path
       @initial_path
     end
-  
+
     def from_number
       @from_number
     end
-  
+
     def to_number
       @to_number
     end
-  
+
     def is_machine
       @is_machine
     end

--- a/lib/twilio-test-toolkit/call_in_progress.rb
+++ b/lib/twilio-test-toolkit/call_in_progress.rb
@@ -3,6 +3,7 @@ require "twilio-test-toolkit/call_scope"
 module TwilioTestToolkit
   # Models a call
   class CallInProgress < CallScope
+    attr_reader :options
     attr_reader :sid, :initial_path, :http_method
     attr_reader :from_number, :to_number
     attr_reader :is_machine, :called, :direction
@@ -12,14 +13,22 @@ module TwilioTestToolkit
     # * :call_sid - specify an optional fixed value to be passed as params[:CallSid]
     # * :is_machine - controls params[:AnsweredBy]
     def initialize(initial_path, from_number, to_number, options = {})
+      default_options = {
+        :method     => :post,
+        :direction  => 'inbound',
+        :is_machine => false
+      }
+
+      @options = default_options.merge(options)
+
       # Save our variables for later
       @initial_path = initial_path
       @from_number  = from_number
       @to_number    = to_number
-      @is_machine   = options[:is_machine]
-      @called       = options[:called]
-      @direction    = options[:direction]
-      @http_method  = options[:method] || :post
+      @is_machine   = @options[:is_machine]
+      @called       = @options[:called]
+      @direction    = @options[:direction]
+      @http_method  = @options[:method]
 
       # Generate an initial call SID if we don't have one
       if (options[:call_sid].nil?)
@@ -32,12 +41,7 @@ module TwilioTestToolkit
       self.root_call = self
 
       # Create the request
-      request_for_twiml!(@initial_path,
-                         :method     => @http_method,
-                         :is_machine => @is_machine,
-                         :called     => @called,
-                         :direction  => @direction
-                        )
+      request_for_twiml!(@initial_path, @options)
     end
 
   end

--- a/lib/twilio-test-toolkit/call_in_progress.rb
+++ b/lib/twilio-test-toolkit/call_in_progress.rb
@@ -3,6 +3,10 @@ require "twilio-test-toolkit/call_scope"
 module TwilioTestToolkit
   # Models a call
   class CallInProgress < CallScope
+    attr_reader :sid, :initial_path, :http_method
+    attr_reader :from_number, :to_number
+    attr_reader :is_machine, :called, :direction
+
     # Initiate a call. Options:
     # * :method - specify the http method of the initial api call
     # * :call_sid - specify an optional fixed value to be passed as params[:CallSid]
@@ -15,7 +19,7 @@ module TwilioTestToolkit
       @is_machine   = options[:is_machine]
       @called       = options[:called]
       @direction    = options[:direction]
-      @method       = options[:method] || :post
+      @http_method  = options[:method] || :post
 
       # Generate an initial call SID if we don't have one
       if (options[:call_sid].nil?)
@@ -29,35 +33,12 @@ module TwilioTestToolkit
 
       # Create the request
       request_for_twiml!(@initial_path,
-                         :method     => @method,
+                         :method     => @http_method,
                          :is_machine => @is_machine,
                          :called     => @called,
                          :direction  => @direction
                         )
     end
 
-    def sid
-      @sid
-    end
-
-    def initial_path
-      @initial_path
-    end
-
-    def from_number
-      @from_number
-    end
-
-    def to_number
-      @to_number
-    end
-
-    def is_machine
-      @is_machine
-    end
-
-    def http_method
-      @method
-    end
   end
 end

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -211,6 +211,8 @@ module TwilioTestToolkit
       # Post and update the scope. Options:
       # :digits - becomes params[:Digits], optional (becomes "")
       # :is_machine - becomes params[:AnsweredBy], defaults to false / human
+      # :called - becomes params[:Called], like when the REST API is used to initiate a call
+      # :direction - becomes params[:Direction]. Should be inbound, outbound-api, or outbound-dial
       def request_for_twiml!(path, options = {})
         @current_path = normalize_redirect_path(path)
 
@@ -223,7 +225,9 @@ module TwilioTestToolkit
           :Digits => formatted_digits(options[:digits].to_s, :finish_on_key => options[:finish_on_key]),
           :To => @root_call.to_number,
           :AnsweredBy => (options[:is_machine] ? "machine" : "human"),
-          :CallStatus => options.fetch(:call_status, "in-progress")
+          :CallStatus => options.fetch(:call_status, "in-progress"),
+          :Called => options.fetch(:called, ""),
+          :Direction => options[:direction].nil? ? "inbound" : options[:direction]
         )
 
         # All Twilio responses must be a success.

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -83,13 +83,13 @@ module TwilioTestToolkit
       #
       # has_finish_on_key_on_record?("#")
       #
-      if meth.to_s =~ /^has_([a-zA-Z_]+)_on_([a-zA-Z]+)\?$/
-        has_attr_on_element?($2, $1, *args, &block)
+      if meth.to_s =~ /^ha(s|ve)_([a-zA-Z_]+)_on_([a-zA-Z]+)\?$/
+        has_attr_on_element?($3, $2, *args, &block)
 
       # support any check for the existence of a given element
       # with an optional check on the inner_text.
-      elsif meth.to_s =~ /^has_([a-zA-Z]+)\?$/
-        has_element?($1, *args, &block)
+      elsif meth.to_s =~ /^ha(s|ve)_([a-zA-Z]+)\?$/
+        has_element?($2, *args, &block)
 
       # get a given element node
       elsif meth.to_s =~ /^get_([a-z]+)_node$/
@@ -107,7 +107,7 @@ module TwilioTestToolkit
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      method_name.to_s.match(/^(has_|get_[a-z]+_node|within_)/) || super
+      method_name.to_s.match(/^(has_|have_|get_[a-z]+_node|within_)/) || super
     end
 
     # Some basic accessors

--- a/lib/twilio-test-toolkit/call_scope.rb
+++ b/lib/twilio-test-toolkit/call_scope.rb
@@ -218,7 +218,7 @@ module TwilioTestToolkit
 
         # Post the query
         rack_test_session_wrapper = Capybara.current_session.driver
-        @response = rack_test_session_wrapper.send(options[:method] || :post, @current_path,
+        @response = rack_test_session_wrapper.send(options[:method].downcase || :post, @current_path,
           :format => :xml,
           :CallSid => @root_call.sid,
           :From => @root_call.from_number,

--- a/lib/twilio-test-toolkit/version.rb
+++ b/lib/twilio-test-toolkit/version.rb
@@ -1,3 +1,3 @@
 module TwilioTestToolkit
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end

--- a/spec/dummy/app/controllers/twilio_controller.rb
+++ b/spec/dummy/app/controllers/twilio_controller.rb
@@ -5,4 +5,8 @@ class TwilioController < ApplicationController
   def test_action
     @digits = params[:Digits]
   end    
+
+  def test_call_status
+    @call_status = params[:CallStatus]
+  end
 end

--- a/spec/dummy/app/views/twilio/test_call_status.xml.erb
+++ b/spec/dummy/app/views/twilio/test_call_status.xml.erb
@@ -1,0 +1,6 @@
+<% if @call_status == 'ringing' %>
+<Say voice="woman">Your call is ringing.</Say>
+<% else %>
+<Say voice="woman">Your call is in progress.</Say>
+<% end %>
+<Redirect><%= twilio_index_path %></Redirect>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,5 +12,6 @@ Dummy::Application.routes.draw do
     post "test_say", :on => :collection
     post "test_play", :on => :collection
     post "test_record", :on => :collection
+    post "test_call_status", :on => :collection
   end
 end

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -384,5 +384,16 @@ describe TwilioTestToolkit::CallScope do
       @call.has_finish_on_key_on_record?("*").should be_true
     end
   end
-end
 
+  describe "conditional handling on call_status" do
+    it "should default to in progress" do
+      @call = ttt_call(test_call_status_twilio_index_path, @our_number, @their_number)
+      @call.should have_say "Your call is in progress."
+    end
+
+    it "should respond differently to a ringing call" do
+      @call = ttt_call(test_call_status_twilio_index_path, @our_number, @their_number, :call_status => 'ringing')
+      @call.should have_say "Your call is ringing."
+    end
+  end
+end

--- a/spec/requests/call_scope_spec.rb
+++ b/spec/requests/call_scope_spec.rb
@@ -3,80 +3,80 @@ require 'spec_helper'
 describe TwilioTestToolkit::CallScope do
   before(:each) do
     @our_number = "2065551212"
-    @their_number = "2065553434"             
+    @their_number = "2065553434"
   end
-  
+
   describe "basics" do
     before(:each) do
       @call = ttt_call(test_start_twilio_index_path, @our_number, @their_number)
     end
-    
+
     it "should be a CallScope" do
       @call.should be_a(TwilioTestToolkit::CallScope)
     end
-    
+
     it "should have the informational methods" do
       @call.should respond_to(:current_path)
       @call.should respond_to(:response_xml)
     end
-    
+
     it "should have the right path" do
       @call.current_path.should == test_start_twilio_index_path
     end
-    
+
     it "should have a response xml value" do
       @call.response_xml.should_not be_blank
     end
-    
+
     it "should have the right root call" do
       @call.should respond_to(:root_call)
       @call.root_call.should == @call
     end
   end
-  
+
   describe "redirect" do
     describe "success" do
       before(:each) do
         @call = ttt_call(test_redirect_twilio_index_path, @our_number, @their_number)
       end
-    
+
       it "should have the redirect methods" do
         @call.should respond_to(:has_redirect?)
         @call.should respond_to(:has_redirect_to?)
         @call.should respond_to(:follow_redirect)
         @call.should respond_to(:follow_redirect!)
       end
-    
+
       it "should have the right value for has_redirect?" do
         @call.should have_redirect
       end
-    
+
       it "should have the right values for has_redirect_to?" do
         @call.has_redirect_to?("http://foo").should be_false
         @call.has_redirect_to?(test_start_twilio_index_path).should be_true
         @call.has_redirect_to?(test_start_twilio_index_path + ".xml").should be_true    # Should force normalization
       end
-      
+
       it "should follow the redirect (immutable version)" do
         # follow_redirect returns a new CallScope
         newcall = @call.follow_redirect
-        
+
         # Make sure it followed
         newcall.current_path.should == test_start_twilio_index_path
-        
+
         # And is not the same call
         newcall.response_xml.should_not == @call.response_xml
         # But it's linked
         newcall.root_call.should == @call
-        
+
         # And we did not modify the original call
         @call.current_path.should == test_redirect_twilio_index_path
       end
-      
+
       it "should follow the redirect (mutable version)" do
         # follow_redirect! modifies the CallScope
         @call.follow_redirect!
-        
+
         # Make sure it followed
         @call.current_path.should == test_start_twilio_index_path
       end
@@ -122,43 +122,43 @@ describe TwilioTestToolkit::CallScope do
         # Initiate a call that's not on a redirect - various calls will fail
         @call = ttt_call(test_say_twilio_index_path, @our_number, @their_number)
       end
-      
+
       it "should have the right value for has_redirect?" do
         @call.should_not have_redirect
       end
-      
+
       it "should have the right values for has_redirect_to?" do
         @call.has_redirect_to?("http://foo").should be_false
         @call.has_redirect_to?(test_start_twilio_index_path).should be_false
         @call.has_redirect_to?(test_start_twilio_index_path + ".xml").should be_false
       end
-      
+
       it "should raise an error on follow_redirect" do
         lambda {@call.follow_redirect}.should raise_error
       end
-      
+
       it "should raise an error on follow_redirect!" do
         lambda {@call.follow_redirect!}.should raise_error
       end
     end
   end
-  
+
   describe "say" do
     before(:each) do
       @call = ttt_call(test_say_twilio_index_path, @our_number, @their_number)
     end
-    
+
     it "should have the expected say methods" do
       @call.should respond_to(:has_say?)
     end
-    
+
     it "should have the right values for has_say?" do
       @call.has_say?("Blah blah").should be_false
       @call.has_say?("This is a say page.").should be_true
       @call.has_say?("This is").should be_true      # Partial match
     end
   end
-  
+
   describe "play" do
     before(:each) do
       @call = ttt_call(test_play_twilio_index_path, @our_number, @their_number)
@@ -226,12 +226,12 @@ describe TwilioTestToolkit::CallScope do
       it "should have the expected hangup methods" do
         @call.should respond_to(:has_hangup?)
       end
-      
+
       it "should have the right value for has_hangup?" do
         @call.should have_hangup
       end
     end
-    
+
     describe "failure" do
       before(:each) do
         @call = ttt_call(test_start_twilio_index_path, @our_number, @their_number)
@@ -242,7 +242,7 @@ describe TwilioTestToolkit::CallScope do
       end
     end
   end
-  
+
   describe "gather" do
     describe "success" do
       before(:each) do
@@ -256,54 +256,54 @@ describe TwilioTestToolkit::CallScope do
         @call.should respond_to(:gather_action)
         @call.should respond_to(:press)
       end
-      
+
       it "should have the right value for has_gather?" do
         @call.has_gather?.should be_true
       end
-      
+
       it "should have the right value for gather?" do
         # Although we have a gather, the current call scope is not itself a gather, so this returns false.
         @call.gather?.should be_false
       end
-      
+
       it "should fail on gather-scoped methods outside of a gather scope" do
         lambda {@call.gather_action}.should raise_error
         lambda {@call.press "1234"}.should raise_error
       end
-      
+
       it "should gather" do
         # We should not have a say that's contained within a gather.
         @call.should_not have_say("Please enter some digits.")
-        
+
         # Now enter the gather block.
         @call.within_gather do |gather|
           # We should have a say here
           gather.should have_say("Please enter some digits.")
-          
+
           # We should be in a gather
           gather.gather?.should be_true
           # And we should have an action
           gather.gather_action.should == test_action_twilio_index_path
-          
+
           # And we should have the right root call
           gather.root_call.should == @call
-          
+
           # Press some digits.
           gather.press "98765"
         end
-        
+
         # This should update the path
         @call.current_path.should == test_action_twilio_index_path
-        
+
         # This view says the digits we pressed - make sure
         @call.should have_say "You entered 98765."
       end
-      
+
       it "should gather without a press" do
         @call.within_gather do |gather|
           # Do nothing
         end
-        
+
         # We should still be on the same page
         @call.current_path.should == test_start_twilio_index_path
       end
@@ -315,7 +315,7 @@ describe TwilioTestToolkit::CallScope do
         @call.should have_say "You entered 98765."
       end
     end
-    
+
     describe "with finishOnKey specified" do
       before(:each) do
         @call = ttt_call(test_gather_finish_on_asterisk_twilio_index_path, @our_number, @their_number)
@@ -343,19 +343,19 @@ describe TwilioTestToolkit::CallScope do
       before(:each) do
         @call = ttt_call(test_say_twilio_index_path, @our_number, @their_number)
       end
-      
+
       it "should have the right value for has_gather?" do
         @call.has_gather?.should be_false
       end
-      
+
       it "should have the right value for gather?" do
         @call.gather?.should be_false
       end
-      
+
       it "should fail on within_gather if there is no gather" do
         lambda {@call.within_gather do |gather|; end}.should raise_error
       end
-      
+
       it "should fail on gather-scoped methods outside of a gather scope" do
         lambda {@call.gather_action}.should raise_error
         lambda {@call.press "1234"}.should raise_error

--- a/spec/requests/dsl_spec.rb
+++ b/spec/requests/dsl_spec.rb
@@ -3,23 +3,23 @@ require 'spec_helper'
 describe TwilioTestToolkit::DSL do
   before(:each) do
     @our_number = "2065551212"
-    @their_number = "2065553434"        
+    @their_number = "2065553434"
   end
-  
+
   describe "ttt_call" do
     describe "basics" do
       before(:each) do
         @call = ttt_call(test_start_twilio_index_path, @our_number, @their_number)
       end
-    
+
       it "should assign the call" do
         @call.should_not be_nil
       end
-    
+
       it "should have a sid" do
         @call.sid.should_not be_blank
       end
-      
+
       it "should default the method to post" do
         @call.http_method.should == :post
       end
@@ -29,25 +29,40 @@ describe TwilioTestToolkit::DSL do
         @call.from_number.should == @our_number
         @call.to_number.should == @their_number
         @call.is_machine.should be_false
-      end      
+      end
     end
-    
+
     describe "with a sid, method and machine override" do
       before(:each) do
         @mysid = "1234567"
         @call = ttt_call(test_start_twilio_index_path, @our_number, @their_number, :call_sid => @mysid, :is_machine => true, :method => :get)
       end
-      
+
       it "should have the right sid" do
         @call.sid.should == @mysid
       end
-      
-      it "should be a machine call" do        
+
+      it "should be a machine call" do
         @call.is_machine.should be_true
       end
 
       it "should be a get call" do
         @call.http_method.should == :get
+      end
+    end
+
+    describe "with a called and direction" do
+      before(:each) do
+        @direction = 'outbound-api'
+        @call = ttt_call(test_start_twilio_index_path, @our_number, @their_number, :direction => @direction, :called => @their_number)
+      end
+
+      it "should have the right direction" do
+        @call.direction.should == @direction
+      end
+
+      it "should have the right called number" do
+        @call.called.should == @their_number
       end
     end
   end


### PR DESCRIPTION
Calls originating from the Twilio REST API include a `Called` parameter. (It seems the same as `To`, but it's only there in that sort of call.) The `Direction` is also `outbound-api`, and so we can now run tests that include both of these parameters:

```
ttt_call('/path', '+16045551234', '+16045556789', :called => '+16045556789', :direction => 'outbound-api')
```

It's also now possible to pass in a different :call_status in order to test on changes there.
